### PR TITLE
Update unistd.rs to make pid_t, uid_t, and gid_t public in unnamed st…

### DIFF
--- a/src/unistd.rs
+++ b/src/unistd.rs
@@ -71,7 +71,7 @@ feature! {
 /// Newtype pattern around `uid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Uid(uid_t);
+pub struct Uid(pub uid_t);
 
 impl Uid {
     /// Creates `Uid` from raw `uid_t`.
@@ -128,7 +128,7 @@ pub const ROOT: Uid = Uid(0);
 /// Newtype pattern around `gid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct Gid(gid_t);
+pub struct Gid(pub gid_t);
 
 impl Gid {
     /// Creates `Gid` from raw `gid_t`.
@@ -180,7 +180,7 @@ feature! {
 /// Newtype pattern around `pid_t` (which is just alias). It prevents bugs caused by accidentally
 /// passing wrong value.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Pid(pid_t);
+pub struct Pid(pub pid_t);
 
 impl Pid {
     /// Creates `Pid` from raw `pid_t`.


### PR DESCRIPTION
…ructs

This is to make the world consistent, it also helps with serialization and deserialization of the structs that use these.